### PR TITLE
chore: ignore all *.sqlite3, not just db.sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ wheels/
 # Virtual environments
 .venv
 
-# sqlite
-db.sqlite3
+# sqlite — pattern must cover db-prod.sqlite3 and any other *.sqlite3
+# dump sitting in the tree. This repo is PUBLIC.
+*.sqlite3
 
 # Logs
 *.log


### PR DESCRIPTION
db-prod.sqlite3 was untracked but unignored in a public repo — one
\`git add -A\` from publishing household finances.
