### PR TITLE
feat: add unauthenticated /api/health for deploy checks

### DIFF
--- a/backend/budget/api.py
+++ b/backend/budget/api.py
@@ -8,12 +8,21 @@ from typing import List, Optional
 import datetime
 import uuid
 import calendar
+import os
 
 from .models import Month, BudgetItem, BudgetItemVersion, TabItem, TabRepayment, NurserySettings
 from django.db.models import Prefetch
 from django.middleware.csrf import get_token
 
 api = NinjaAPI(auth=django_auth)
+
+
+# auth=None is REQUIRED: the deploy pipeline polls this unauthenticated to
+# decide whether a release is healthy or must be rolled back. Inheriting the
+# API-wide django_auth would return 401 and fail every deploy.
+@api.get("/health", auth=None)
+def health(request):
+    return {"status": "ok", "sha": os.environ.get("GIT_SHA", "unknown")}
 
 # --- Schemas ---
 

--- a/backend/budget/tests_health.py
+++ b/backend/budget/tests_health.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+
+from django.test import TestCase
+
+
+class HealthEndpointTests(TestCase):
+    """The deploy pipeline polls /api/health to decide whether to roll back,
+    so it must answer without a session — the rest of the API uses
+    NinjaAPI(auth=django_auth), which would return 401 here."""
+
+    def test_health_is_reachable_without_authentication(self):
+        response = self.client.get("/api/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+    def test_health_reports_the_build_sha(self):
+        with mock.patch.dict(os.environ, {"GIT_SHA": "abc1234"}):
+            response = self.client.get("/api/health")
+        self.assertEqual(response.json()["sha"], "abc1234")
+
+    def test_health_sha_falls_back_when_unset(self):
+        # patch.dict without clear=True snapshots and restores os.environ, so
+        # popping inside the block is safe and scoped to this test.
+        with mock.patch.dict(os.environ):
+            os.environ.pop("GIT_SHA", None)
+            response = self.client.get("/api/health")
+        self.assertEqual(response.json()["sha"], "unknown")


### PR DESCRIPTION
The deploy pipeline polls this to decide whether to roll back. auth=None
is required — the API is NinjaAPI(auth=django_auth), so an inherited-auth
health route would 401 and fail every deploy.
