### PR TITLE
feat: extract deploy config into a testable stdlib-only module

### DIFF
--- a/deploy_config.py
+++ b/deploy_config.py
@@ -1,0 +1,62 @@
+"""Deploy configuration, resolved from environment variables.
+
+Imported by tasks.py and unit-tested directly. Deliberately stdlib-only:
+tasks.py imports invoke, which is not a project dependency, so config logic
+placed there could not be tested.
+
+Every default reproduces the historic .191 behaviour, so `inv release` from a
+laptop with no environment set behaves exactly as it always has. CI on .137
+overrides via BUDGETER_* variables.
+"""
+import os
+
+DEFAULT_REGISTRY = "192.168.0.191:5000"
+DEFAULT_PROD_HOST = "192.168.0.191"
+
+# Non-secret compose interpolation vars only. Real secrets (DJANGO_SECRET_KEY,
+# GOOGLE_CLIENT_ID/SECRET, ADDON_DOMAIN, HA_*) are decrypted inside the
+# container at start-up by `envars exec` and never appear here.
+ENV_COMPOSE_VARS = {
+    "demo": {"BUDGETER_PORT": "8081", "COMPOSE_PROJECT_NAME": "budgeter-demo"},
+    "prod": {"BUDGETER_PORT": "8080", "COMPOSE_PROJECT_NAME": "budgeter"},
+}
+
+
+def _env(environ):
+    return os.environ if environ is None else environ
+
+
+def registry(environ=None):
+    return _env(environ).get("BUDGETER_REGISTRY", DEFAULT_REGISTRY)
+
+
+def prod_host(environ=None):
+    return _env(environ).get("BUDGETER_PROD_HOST", DEFAULT_PROD_HOST)
+
+
+def is_local(environ=None):
+    """True when the deploy runs on the target host itself (the CI runner on
+    .137), so commands execute directly instead of over SSH. Avoids giving the
+    runner a root SSH key — it only needs docker-group membership."""
+    return _env(environ).get("BUDGETER_DEPLOY_LOCAL", "") == "1"
+
+
+def use_buildx(environ=None):
+    """The laptop path cross-builds linux/amd64 via the `amd64builder` buildx
+    builder. The .137 runner is native amd64 and has no such builder, so CI
+    sets BUDGETER_BUILDX=0 for a plain `docker build`."""
+    return _env(environ).get("BUDGETER_BUILDX", "1") != "0"
+
+
+def stack_dir(env):
+    if env == "prod":
+        return "/opt/stacks/budgeter"
+    return f"/opt/stacks/budgeter-{env}"
+
+
+def env_lines(env, tag):
+    """Lines for the stack's .env file. Raises KeyError for unknown envs."""
+    compose_vars = ENV_COMPOSE_VARS[env]
+    lines = [f"APP_ENV={env}", f"IMAGE_TAG={tag}"]
+    lines += [f"{k}={v}" for k, v in compose_vars.items()]
+    return lines

--- a/tests/test_deploy_config.py
+++ b/tests/test_deploy_config.py
@@ -1,0 +1,96 @@
+"""Stdlib-only tests: `python3 -m unittest discover -s tests`.
+
+deploy_config must not import invoke (not a project dependency), which is
+exactly why the config logic lives there rather than in tasks.py.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import deploy_config
+
+
+class DefaultsTests(unittest.TestCase):
+    """Defaults must reproduce today's .191 behaviour byte for byte —
+    Tild's `inv release` runs with no env vars set and must not change."""
+
+    def test_registry_defaults_to_191(self):
+        self.assertEqual(deploy_config.registry({}), "192.168.0.191:5000")
+
+    def test_prod_host_defaults_to_191(self):
+        self.assertEqual(deploy_config.prod_host({}), "192.168.0.191")
+
+    def test_not_local_by_default(self):
+        self.assertFalse(deploy_config.is_local({}))
+
+    def test_buildx_enabled_by_default(self):
+        self.assertTrue(deploy_config.use_buildx({}))
+
+
+class OverrideTests(unittest.TestCase):
+    def test_registry_override(self):
+        self.assertEqual(
+            deploy_config.registry({"BUDGETER_REGISTRY": "localhost:5000"}),
+            "localhost:5000",
+        )
+
+    def test_prod_host_override(self):
+        self.assertEqual(
+            deploy_config.prod_host({"BUDGETER_PROD_HOST": "192.168.0.137"}),
+            "192.168.0.137",
+        )
+
+    def test_local_mode_enabled_by_exactly_one(self):
+        self.assertTrue(deploy_config.is_local({"BUDGETER_DEPLOY_LOCAL": "1"}))
+        self.assertFalse(deploy_config.is_local({"BUDGETER_DEPLOY_LOCAL": "0"}))
+        self.assertFalse(deploy_config.is_local({"BUDGETER_DEPLOY_LOCAL": ""}))
+
+    def test_buildx_disabled_by_zero(self):
+        self.assertFalse(deploy_config.use_buildx({"BUDGETER_BUILDX": "0"}))
+
+
+class StackDirTests(unittest.TestCase):
+    def test_prod_has_no_suffix(self):
+        self.assertEqual(deploy_config.stack_dir("prod"), "/opt/stacks/budgeter")
+
+    def test_demo_is_suffixed(self):
+        self.assertEqual(deploy_config.stack_dir("demo"), "/opt/stacks/budgeter-demo")
+
+
+class EnvLinesTests(unittest.TestCase):
+    def test_prod_env_lines(self):
+        self.assertEqual(
+            deploy_config.env_lines("prod", "abc1234"),
+            [
+                "APP_ENV=prod",
+                "IMAGE_TAG=abc1234",
+                "BUDGETER_PORT=8080",
+                "COMPOSE_PROJECT_NAME=budgeter",
+            ],
+        )
+
+    def test_demo_env_lines(self):
+        self.assertEqual(
+            deploy_config.env_lines("demo", "abc1234"),
+            [
+                "APP_ENV=demo",
+                "IMAGE_TAG=abc1234",
+                "BUDGETER_PORT=8081",
+                "COMPOSE_PROJECT_NAME=budgeter-demo",
+            ],
+        )
+
+    def test_app_env_is_first_and_drives_secret_decryption(self):
+        # APP_ENV is the -e argument to `envars exec` in the Dockerfile CMD:
+        # it selects WHICH environment's secrets get decrypted at boot.
+        self.assertTrue(deploy_config.env_lines("demo", "x")[0].startswith("APP_ENV="))
+
+    def test_unknown_env_raises(self):
+        with self.assertRaises(KeyError):
+            deploy_config.env_lines("staging", "abc1234")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
tasks.py imports invoke, which isn't a project dependency and so can't be
imported by tests. deploy_config has no third-party imports. Defaults
reproduce today's .191 behaviour exactly.
