### PR TITLE
Make /api/health probe the schema, and require it in the deploy pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,13 +284,19 @@ jobs:
             # container answers 200 just as happily. An unparseable body is
             # "not healthy yet": keep polling instead of crashing the step.
             got=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha",""))' 2>/dev/null || true)
-            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" = "$WANT" ]; then
+            # /api/health also runs a real query (BudgetItem.objects.first())
+            # against the schema and reports "degraded" (HTTP 503) if it
+            # raises — a schema/code mismatch after a bad migration. A 200
+            # with the right sha is not enough; status must be "ok" too, or a
+            # broken-schema release would be waved through as healthy.
+            status=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" = "$WANT" ] && [ "$status" = "ok" ]; then
               echo "healthy after ${attempt} attempt(s) — serving $got (Host: $domain)"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::health check never reported sha=$WANT within ~120s (last code: ${code:-none}, last sha: ${got:-none}, last domain: ${domain:-none})"
+          echo "::error::health check never reported sha=$WANT status=ok within ~120s (last code: ${code:-none}, last sha: ${got:-none}, last status: ${status:-none}, last domain: ${domain:-none})"
           exit 1
 
       - name: Roll back
@@ -354,7 +360,13 @@ jobs:
             # sha. IMAGE_TAG is normally the git sha, but a hand-run
             # `inv deploy --tag latest` would break an equality test and block
             # a rollback that actually worked.
-            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" != "$NEW" ]; then
+            #
+            # status must also be "ok": the rolled-back image's code could
+            # itself be running against a schema a later, since-reverted
+            # migration already moved forward (migrations have no down path)
+            # — a 503/degraded rollback target is not a successful rollback.
+            status=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" != "$NEW" ] && [ "$status" = "ok" ]; then
               # Says only what the test proves. `got != NEW` shows the failing
               # build is gone and something healthy took over; it does NOT show
               # that something is $PREV (any third build would pass too), so
@@ -364,7 +376,7 @@ jobs:
             fi
             sleep 2
           done
-          echo "::error::deploy of $NEW failed AND the rollback to $PREV never produced a healthy build other than $NEW within ~120s — manual intervention required"
+          echo "::error::deploy of $NEW failed AND the rollback to $PREV never produced a healthy (status=ok) build other than $NEW within ~120s (last status: ${status:-none}) — manual intervention required"
           exit 1
 
       - name: Fail the job if the deploy or health check failed
@@ -512,13 +524,16 @@ jobs:
             # Assert the sha the container reports is the build we deployed; a
             # stale container also returns 200. Unparseable => keep polling.
             got=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha",""))' 2>/dev/null || true)
-            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" = "$WANT" ]; then
+            # See deploy-demo: status must also be "ok" — a 503/degraded body
+            # (schema/code mismatch) must not be accepted as healthy.
+            status=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" = "$WANT" ] && [ "$status" = "ok" ]; then
               echo "healthy after ${attempt} attempt(s) — serving $got (Host: $domain)"
               exit 0
             fi
             sleep 2
           done
-          echo "::error::health check never reported sha=$WANT within ~120s (last code: ${code:-none}, last sha: ${got:-none}, last domain: ${domain:-none})"
+          echo "::error::health check never reported sha=$WANT status=ok within ~120s (last code: ${code:-none}, last sha: ${got:-none}, last status: ${status:-none}, last domain: ${domain:-none})"
           exit 1
 
       - name: Roll back
@@ -564,13 +579,16 @@ jobs:
             # Looser than the forward check on purpose — see deploy-demo. The
             # message claims only what this proves: the failing build is gone
             # and $got is serving, not that $got is $PREV.
-            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" != "$NEW" ]; then
+            #
+            # status must also be "ok" — see deploy-demo's rollback loop.
+            status=$(printf '%s' "$body" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+            if [ "$code" = "200" ] && [ -n "$got" ] && [ "$got" != "$NEW" ] && [ "$status" = "ok" ]; then
               echo "::error::deploy of $NEW failed; it is no longer being served — $got is now serving and healthy (rollback targeted $PREV)"
               exit 1
             fi
             sleep 2
           done
-          echo "::error::deploy of $NEW failed AND the rollback to $PREV never produced a healthy build other than $NEW within ~120s — manual intervention required"
+          echo "::error::deploy of $NEW failed AND the rollback to $PREV never produced a healthy (status=ok) build other than $NEW within ~120s (last status: ${status:-none}) — manual intervention required"
           exit 1
 
       - name: Fail the job if the deploy or health check failed

--- a/backend/budget/api.py
+++ b/backend/budget/api.py
@@ -20,9 +20,26 @@ api = NinjaAPI(auth=django_auth)
 # auth=None is REQUIRED: the deploy pipeline polls this unauthenticated to
 # decide whether a release is healthy or must be rolled back. Inheriting the
 # API-wide django_auth would return 401 and fail every deploy.
-@api.get("/health", auth=None)
+@api.get("/health", auth=None, response={200: dict, 503: dict})
 def health(request):
-    return {"status": "ok", "sha": os.environ.get("GIT_SHA", "unknown")}
+    # `os.environ.get("GIT_SHA") or "unknown"`, NOT the two-arg form: the
+    # Dockerfile's `ARG GIT_SHA` / `ENV GIT_SHA=${GIT_SHA}` bakes an EMPTY
+    # STRING into the image (not an absent var) when a build omits
+    # --build-arg, and .get(key, default) only substitutes on a missing key.
+    sha = os.environ.get("GIT_SHA") or "unknown"
+    try:
+        # BudgetItem.objects.first() is the probe, deliberately not
+        # .exists(): .exists() compiles to `SELECT 1`, which is satisfied by
+        # any schema at all, while .first() SELECTs every column the model
+        # declares — a removed/renamed column (see ee4ce43's bare
+        # RemoveField) raises here instead of only on a real user request.
+        BudgetItem.objects.first()
+    except Exception as e:
+        # Broad by design: this endpoint's job is to report, never to raise.
+        # Only the exception class name goes out — no message, no SQL — this
+        # is unauthenticated on a public-facing app.
+        return 503, {"status": "degraded", "sha": sha, "error": type(e).__name__}
+    return {"status": "ok", "sha": sha}
 
 # --- Schemas ---
 

--- a/backend/budget/tests_health.py
+++ b/backend/budget/tests_health.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 from django.test import TestCase
 
+from .models import BudgetItem
+
 
 class HealthEndpointTests(TestCase):
     """The deploy pipeline polls /api/health to decide whether to roll back,
@@ -26,3 +28,57 @@ class HealthEndpointTests(TestCase):
             os.environ.pop("GIT_SHA", None)
             response = self.client.get("/api/health")
         self.assertEqual(response.json()["sha"], "unknown")
+
+    def test_health_sha_falls_back_when_empty_string(self):
+        # `ENV GIT_SHA=${GIT_SHA}` off an unset build-arg bakes an EMPTY
+        # STRING into the image, not an absent var — a plain `docker build .`
+        # with no --build-arg hits this. os.environ.get(key, "x") only
+        # substitutes on a missing key, not an empty value, so the fallback
+        # must be `or "unknown"`.
+        with mock.patch.dict(os.environ, {"GIT_SHA": ""}):
+            response = self.client.get("/api/health")
+        self.assertEqual(response.json()["sha"], "unknown")
+
+    def test_health_probes_the_real_schema(self):
+        # .exists() compiles to SELECT 1 and would pass against a schema
+        # missing a real column; .first() selects every field the model
+        # declares, so a removed/renamed column actually surfaces here.
+        with mock.patch.object(
+            BudgetItem.objects, "first", wraps=BudgetItem.objects.first
+        ) as spy:
+            response = self.client.get("/api/health")
+        spy.assert_called_once()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+    def test_health_reports_degraded_on_database_error(self):
+        with mock.patch.dict(os.environ, {"GIT_SHA": "deadbee"}):
+            with mock.patch.object(
+                BudgetItem.objects,
+                "first",
+                side_effect=Exception("no such column: budget_budgetitem.owner"),
+            ):
+                response = self.client.get("/api/health")
+        self.assertEqual(response.status_code, 503)
+        body = response.json()
+        self.assertEqual(body["status"], "degraded")
+        self.assertEqual(body["sha"], "deadbee")
+        self.assertEqual(body["error"], "Exception")
+        # No SQL, no exception message — this endpoint is unauthenticated.
+        serialized = response.content.decode()
+        self.assertNotIn("no such column", serialized)
+        self.assertNotIn("budget_budgetitem", serialized)
+
+    def test_health_reports_degraded_with_specific_exception_class_name(self):
+        # A more realistic failure: a real OperationalError, not a bare
+        # Exception — the reported name must reflect the actual type.
+        from django.db import OperationalError
+
+        with mock.patch.object(
+            BudgetItem.objects,
+            "first",
+            side_effect=OperationalError("no such column: owner"),
+        ):
+            response = self.client.get("/api/health")
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"], "OperationalError")


### PR DESCRIPTION
## Problem

`run.sh` runs `./manage.py migrate --no-input` on every container start, so a new image moves the schema forward the moment it boots. Django has no down-migrations, so the CI pipeline's rollback only restores the previous *image*, not the schema. `/api/health` returned a static dict and touched no database at all — so after a rollback across a destructive migration (the repo has precedent: `ee4ce43` shipped a bare `RemoveField`), the old code runs against the new schema, every real request 500s with `OperationalError: no such column`, and the health check cheerfully returns 200. The pipeline then reports "rolled back successfully — now serving and healthy" on a dead app.

## Fix

**`backend/budget/api.py`** — `/api/health` now calls `BudgetItem.objects.first()` (not `.exists()`, which compiles to `SELECT 1` and would pass against a broken schema) inside a broad `try/except`:
- Healthy: `200 {"status": "ok", "sha": "<GIT_SHA>"}` — unchanged shape.
- DB/schema failure: `503 {"status": "degraded", "sha": "<GIT_SHA>", "error": "<ExceptionClassName>"}` — no exception message or SQL leaked; this endpoint is unauthenticated.

Also fixed a latent bug while in this line: `ENV GIT_SHA=${GIT_SHA}` off an unset build-arg bakes an **empty string** into the image, not an absent var, so a plain `docker build .` returned `sha=""`. Switched to `os.environ.get("GIT_SHA") or "unknown"`.

**`.github/workflows/ci.yml`** — updated all four probe loops (health check + rollback verification, in both `deploy-demo` and `deploy-prod`) to also require `status == "ok"`, so a 503/degraded response is treated as unhealthy and the loop keeps polling until it times out (and rolls back / fails the job), instead of declaring victory on a 200 with a matching sha alone. All existing behaviour preserved: the sha assertion, the `Host` header handling read from the container's PID 1, `--max-time 5 --connect-timeout 2`, the ~120s budget, and the rollback loop's "serving sha differs from the failed one" test.

No changes to `run.sh`/migration behaviour (separate decision), the `if:` gating on either deploy job, or the `backend`/`frontend`/`image`/`e2e` job definitions.

## Testing

Written first in `backend/budget/tests_health.py` (confirmed failing before the implementation), covering: healthy 200/ok; DB failure → 503/degraded with the class name and no message leakage (generic `Exception` and a realistic `OperationalError`); the probe actually calls `BudgetItem.objects.first()`; `GIT_SHA` empty-string → falls back to `"unknown"` (in addition to the pre-existing unset-var case). Full backend suite: 49 → 53 tests, green.

Verified against the real `budgeter-demo` container on `.137` that the **current** (unfixed, pre-this-PR) deploy returns `200 {"status": "ok", "sha": "ff386fe"}` — confirming the baseline this PR changes. The 503/degraded path itself is proven by unit test only in this PR — it cannot be demonstrated against the live container without deploying the fix, which happens on merge, not now.

## Test plan
- [x] `cd backend && uv run manage.py test` — 53 tests, green
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML OK')"` — OK
- [x] Confirmed pre-fix baseline against the real `budgeter-demo` container on `.137`
- [ ] CI: `backend`/`frontend`/`image`/`e2e` green on this PR; `deploy-demo`/`deploy-prod` skipped (PR event, not push-to-main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQjycGWcJoRCZJNyxrP3LD