### PR TITLE
fix: pin the compose file name so Dockge cannot shadow it

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -28,6 +28,13 @@ import deploy_config
 # Defaults reproduce today's .191 behaviour exactly.
 REGISTRY = deploy_config.registry()
 REPO = "budgeter"
+# Always name the compose file explicitly. Bare `docker compose` picks the
+# first match of compose.yaml, compose.yml, docker-compose.yaml,
+# docker-compose.yml — and compose.yaml WINS over the compose.yml the deploy
+# writes. Dockge manages /opt/stacks and writes compose.yaml, so one Save in
+# its UI would silently shadow this file: deploys would keep reporting green
+# while compose read a file the repo no longer controls.
+COMPOSE = "docker compose -f compose.yml"
 PROD_USER = "root"
 DEFAULT_ENV = "demo"
 TARGET_PLATFORM = "linux/amd64"
@@ -169,9 +176,9 @@ def deploy(c, env=DEFAULT_ENV, tag=None):
         c.run(f"cat compose.yml | ssh {remote} 'cat > {prod_dir}/compose.yml'")
 
     print("Pulling image...")
-    _ssh(c, "docker compose pull", env)
+    _ssh(c, f"{COMPOSE} pull", env)
     print(f"Starting ({env})...")
-    _ssh(c, "docker compose up -d", env)
+    _ssh(c, f"{COMPOSE} up -d", env)
 
     print(f"\nDeployed {sha} to {env}")
 
@@ -189,16 +196,16 @@ def release(c, env=DEFAULT_ENV):
 @task
 def logs(c, env=DEFAULT_ENV):
     """Tail logs."""
-    _ssh(c, "docker compose logs -f --tail=50", env)
+    _ssh(c, f"{COMPOSE} logs -f --tail=50", env)
 
 
 @task
 def status(c, env=DEFAULT_ENV):
     """Show running containers."""
-    _ssh(c, "docker compose ps", env)
+    _ssh(c, f"{COMPOSE} ps", env)
 
 
 @task
 def stop(c, env=DEFAULT_ENV):
     """Stop the stack."""
-    _ssh(c, "docker compose down", env)
+    _ssh(c, f"{COMPOSE} down", env)


### PR DESCRIPTION
## What

Routes all five `docker compose` invocations in `tasks.py` through a single
`COMPOSE = "docker compose -f compose.yml"` constant.

## Why

Bare `docker compose` resolves the **first** of `compose.yaml`, `compose.yml`,
`docker-compose.yaml`, `docker-compose.yml` — and `compose.yaml` **wins** over the
`compose.yml` our deploy writes.

Dockge manages `/opt/stacks` on the deploy host and writes `compose.yaml`. One Save in
the Dockge UI would therefore leave the stack running from a file the repo no longer
controls — permanently, and with no signal: CI would keep writing `compose.yml`, keep
writing `.env`, keep passing its health check at the right sha, and keep reporting
green, while every future change to `compose.yml` silently never shipped.

`.137` currently has 7 stacks using `.yml` and 2 using `.yaml`, so the mix is already
there — this just makes budgeter immune to it.

## Verification

- `inv --list` — imports cleanly
- `python3 -m unittest discover -s tests` — 16/16
- `inv status --env prod` against the live `.191` host — the `-f` flag works over the
  SSH path (returned the running prod container)

Found by the final whole-branch review of the CI/CD pilot; recorded as open finding #3
in the homelab spec.