### PR TITLE
ci: require human approval before deploying prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,14 @@ jobs:
         run: exit 1
 
   deploy-prod:
+    # Requires a human approval before anything runs. The `prod` environment
+    # carries a required-reviewers rule (Keith + Tild), so on a merge this job
+    # QUEUES and waits: demo has already deployed automatically, prod does not
+    # start until someone clicks Approve in the Actions UI. The runner is not
+    # occupied while it waits, and the same gate applies to a manual
+    # `workflow_dispatch env=prod`. The environment is also pinned to protected
+    # branches, so only `main` can deploy through it.
+    environment: prod
     # Depends on deploy-demo so a build that fails demo's health check can
     # never reach real data — and, on the push-to-main path, so this job can
     # promote demo's already-validated image rather than build its own (see the


### PR DESCRIPTION
## What

`deploy-prod` now runs in the `prod` GitHub Environment, which has a
required-reviewers protection rule.

## Behaviour after this merges

| Trigger | demo | prod |
|---|---|---|
| merge to `main` | deploys automatically | **queues, waits for Approve** |
| `workflow_dispatch env=demo` | deploys automatically | not run |
| `workflow_dispatch env=prod` | not run | **queues, waits for Approve** |

Demo is unchanged — it still deploys straight off a merge, health-checks itself and
rolls back on failure. Only prod gains the gate.

## Details

- Reviewers: **kthhrv** and **mathildedelenclos** — either can approve, so neither of us
  blocks the other when one is away.
- The environment is pinned to **protected branches**, so only `main` can deploy through
  it (belt and braces with the existing `if:` restriction).
- A waiting job does **not** occupy the self-hosted runner.
- Approvals appear in the Actions run, and GitHub notifies reviewers.
- Deployments are now recorded under the repo's Environments tab, so there's a history of
  what went to prod and who approved it.

Requested by Tild: demo should keep flowing freely, but the instance the family actually
uses shouldn't restart unattended.

If we later want a genuine second pair of eyes rather than a speed bump, the environment
has a `prevent_self_review` flag that stops whoever pushed the change from approving it.
Left off for now, since it would mean neither of us can ship prod alone.