### PR TITLE
chore: bump actions to v7 to clear the Node 20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
@@ -51,9 +51,9 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -80,7 +80,7 @@ jobs:
     # rather than on the homelab after merge.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build image
         run: docker build --build-arg GIT_SHA="${GITHUB_SHA::7}" -t budgeter:ci .
 
@@ -93,14 +93,14 @@ jobs:
     # Promote to required once it has proven stable.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/0.7.14/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm
@@ -190,7 +190,7 @@ jobs:
       # ADDON_DOMAIN out of the container (see those steps for why).
       CONTAINER: budgeter-demo
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Put uv and inv on PATH
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
@@ -436,7 +436,7 @@ jobs:
       # "budgeter" in deploy_config.py, so that's always the container name.
       CONTAINER: budgeter
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Put uv and inv on PATH
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## What

`actions/checkout@v4` → `@v7` (6 call sites) and `actions/setup-node@v4` → `@v7`
(2 call sites). No other changes.

## Why

Every run currently emits six warnings — one per job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced
> to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4

It's not cosmetic. When GitHub retires the Node 20 runtime, `@v4` stops working rather
than warning — and `checkout` runs in `deploy-demo` / `deploy-prod` too, so that would
take the deploy path down, not just the tests.

## Risk and why it's contained

v4 → v7 is a three-major jump, so this PR is the test: all four GitHub-hosted checks
exercise both actions before anything merges, and on merge `deploy-demo` exercises
`checkout` on the self-hosted runner with a health check and automatic rollback behind
it. A break shows up on the PR or costs demo — not prod.

Checked before pushing: the self-hosted runner bundles `node24` (as well as `node20`),
so it can run the v7 actions.

Both actions remain GitHub-owned, so the repo's `allowed_actions` restriction
(github-owned only) still permits them.