### PR TITLE
docs: make the manual deploy path clearly the fallback, and gate it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Budgeter is a full-stack budgeting app deployed via Dockge on 192.168.0.191. It tracks shared and individual budgets for multiple users with temporal versioning of budget values.
+Budgeter is a full-stack budgeting app. It is deployed by CI (GitHub Actions) to 192.168.0.137 on every merge to `main`; the live instance still runs on 192.168.0.191 until the data is migrated. See README.md for the deploy flow. It tracks shared and individual budgets for multiple users with temporal versioning of budget values.
 
 ## Commands
 
@@ -28,16 +28,18 @@ cd backend && uv run manage.py test budget.tests.TestClassName.test_method
 # Frontend linting
 cd frontend && npm run lint
 
-# Deploy (via invoke)
+# Deploy — NORMAL PATH: merge a PR to main. CI builds, deploys demo,
+# health-checks it, then promotes to prod after a human approval.
+#
+# The invoke tasks below are the FALLBACK for when the pipeline is broken.
+# They bypass tests, health checks and rollback. deploy/release/stop ask for
+# a typed confirmation (--yes skips it; CI skips it automatically).
 inv build                # Build Docker image (SHA + latest)
-inv push                 # Push to 192.168.0.191:5000 registry
-inv deploy               # Deploy to demo (default)
-inv deploy --env prod    # Deploy to prod
-inv release              # Build + push + deploy (demo)
-inv release --env prod   # Full release to prod
-inv logs                 # Tail logs (demo)
-inv logs --env prod      # Tail logs (prod)
-inv status               # Show containers
+inv push                 # Push to the registry
+inv deploy --env prod    # Deploy to prod  (confirmation required)
+inv release --env prod   # Build + push + deploy (confirmation required)
+inv logs --env prod      # Tail logs
+inv status --env prod    # Show containers
 ```
 
 All `uv run manage.py` commands must be run from the `backend/` directory.
@@ -61,11 +63,20 @@ Client → Nginx Proxy Manager (HA) → Docker container on 191
 
 ### Deploy Flow
 ```
-inv release --env demo
-  1. docker build (tagged with git SHA + latest)
-  2. docker push to 192.168.0.191:5000
-  3. SSH to 191: write .env, sync compose.yml, pull, up -d
+merge to main
+  1. PR checks (Django, vitest+lint+build, docker build, Playwright e2e) — all required
+  2. deploy-demo   on a self-hosted runner ON 192.168.0.137:
+       build -> push to localhost:5000 -> write .env + compose.yml -> up -d
+       -> poll /api/health (200 + status:ok + matching sha)
+       -> on failure, redeploy the previous IMAGE_TAG and fail the run
+  3. deploy-prod   same host, PROMOTES demo's exact image (no rebuild),
+       gated on the `prod` environment: waits for a reviewer to approve
 ```
+Fallback (`inv release --env prod`) still does build -> push -> SSH -> up -d
+against 192.168.0.191, with no health check or rollback.
+
+`deploy_config.py` holds the host/registry/stack-dir values so they can be
+unit-tested and overridden by `BUDGETER_*` env vars in CI; `tasks.py` consumes it.
 
 Remote directory structure:
 - Demo: `/opt/stacks/budgeter-demo/`
@@ -75,7 +86,10 @@ Remote directory structure:
 - `budget/models.py` — Three models: `Month`, `BudgetItem`, `BudgetItemVersion`
 - `budget/api.py` — All REST endpoints under `/api/`
 - `budgeter/adapters.py` — OAuth email whitelist
-- `budgeter/settings.py` — Django config (loads envars at startup)
+- `budgeter/settings.py` — Django config. Reads plain env vars; it does NOT load
+  envars itself. The Dockerfile's `CMD envars -f /app/envars.yml exec -e $APP_ENV`
+  decrypts them at container start and injects them into PID 1. So
+  `docker exec <c> env` will NOT show them — read `/proc/1/environ` instead.
 - `envars.yml` — Vault-backed secrets per environment
 
 ### Data Model Concepts
@@ -85,7 +99,7 @@ Remote directory structure:
 - **Soft deletion**: Items expire via `last_payment_month` rather than being deleted
 
 ### Frontend
-The frontend is a monolithic `App.jsx` containing all components, state management, and an `apiService` object for API calls. It's a PWA with a service worker that excludes `/api/`, `/accounts/`, `/admin/`, `/static/` routes.
+`App.jsx` (~390 lines) holds routing and top-level state; components live in `src/components/`, with `src/hooks/`, `src/services/api.js` and `src/utils/` alongside. It's a PWA with a service worker that excludes `/api/`, `/accounts/`, `/admin/`, `/static/` routes.
 
 ### Auth
 Google OAuth with a hardcoded email whitelist in `adapters.py`. In local dev, authentication is bypassed/simplified. CSRF tokens are required for state-changing API calls.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
+# Budgeter
 
-build
------
+## Deploying
+
+**Normal path — merge a PR to `main`.** That's it. CI does the rest:
+
+1. Your PR runs the tests (Django, vitest, lint, a Docker build, and the
+   Playwright end-to-end suite). All five must pass before it can merge.
+2. On merge, the app deploys to **demo** automatically, on `192.168.0.137`.
+   CI then polls `/api/health` and, if the release is unhealthy, **rolls back
+   to the previous image by itself** and marks the run red.
+3. **prod waits for a human.** It only deploys after demo is green *and*
+   someone approves it in the Actions tab. Keith and Tild can both approve.
+
+Watch it at https://github.com/kthhrv/budgeter/actions.
+
+### Fallback: deploying by hand
+
+`inv` still deploys directly over SSH, bypassing all of the above — no tests,
+no health check, no rollback, no record of what was deployed. Use it when the
+pipeline is broken or GitHub is unreachable.
+
+```bash
+inv release --env prod    # asks you to type "prod" before it does anything
+```
+
+Today it is also the **only** way to update the live app, because
+`budgeter.ddns.net` still points at the old host (`192.168.0.191`). Once that
+moves to `.137`, merging to `main` becomes the way real releases happen and
+`inv` is purely the emergency exit.
+
+## Building and running locally
+
+### build
 
 ```
 docker build -t budgeter -f Dockerfile .
 ```
 
-run
----
+### run
 
 ```
 docker run -p8000:80 -v /tmp/data:/data -it budgeter
 ```
 
-Local Development
------------------
-
-You can run the project locally using the provided `Makefile`.
+## Local Development
 
 **Prerequisites:**
 - `uv` (for Python dependency management)
@@ -24,22 +51,26 @@ You can run the project locally using the provided `Makefile`.
 
 **Commands:**
 
-- **Install Dependencies**:
+- **Install dependencies**:
   ```bash
-  make install
+  cd backend && uv sync
+  cd frontend && npm install
   ```
 
-- **Run Backend**:
+- **Run backend**:
   ```bash
-  make run-backend
+  cd backend && uv run manage.py runserver 0.0.0.0:8000
   ```
 
-- **Run Frontend**:
+- **Run frontend**:
   ```bash
-  make run-frontend
+  cd frontend && npm run dev
   ```
 
-- **Run Tests**:
+- **Run tests**:
   ```bash
-  make test
+  cd backend && uv run manage.py test      # Django
+  cd frontend && npm run test              # vitest
+  cd frontend && npm run test:e2e          # Playwright (boots both servers itself)
+  python3 -m unittest discover -s tests    # deploy config, from the repo root
   ```

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,13 @@
-"""Deployment tasks for budgeter.
+"""Deployment tasks for budgeter — the FALLBACK deploy path.
+
+Normal deploys happen by merging to `main`: CI runs the tests, deploys demo,
+health-checks it, and promotes to prod behind a required approval, rolling
+back automatically if the health check fails.
+
+These tasks bypass all of that. They exist for when the pipeline is broken or
+GitHub is unreachable. The mutating ones (deploy / release / stop) ask for a
+typed confirmation; pass `--yes` to skip it, and CI skips it automatically.
+
 
 Usage:
     inv build                     Build image tagged with git SHA + latest
@@ -17,9 +26,10 @@ override the defaults above for CI; see deploy_config.py.
 
 import io
 import os
+import sys
 import tempfile
 
-from invoke import task
+from invoke import Exit, task
 
 import deploy_config
 
@@ -50,6 +60,53 @@ BUILDKITD_CONFIG = f'''[registry."{REGISTRY}"]
 '''
 
 IMAGE = f"{REGISTRY}/{REPO}"
+
+
+def _confirm_manual(action, env, yes=False):
+    """Gate the mutating tasks behind a typed confirmation.
+
+    Deploys normally happen by merging to `main`: CI builds, deploys demo,
+    health-checks it and only then promotes to prod behind an approval. This
+    path bypasses all of that — no tests, no health check, no rollback, no
+    record of who deployed what. It exists as the fallback for when the
+    pipeline itself is broken or unavailable.
+
+    Never prompts in CI (the pipeline drives these same tasks, and hanging a
+    deploy on input nobody can give would be worse than not asking). With no
+    terminal and no CI marker it refuses outright rather than proceeding —
+    a script must say --yes.
+    """
+    if yes or os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+        return
+    if not sys.stdin.isatty():
+        # Fail closed. Skipping the prompt here would let a script or cron
+        # deploy prod silently, which is exactly what this guard is for.
+        raise Exit(
+            f"Refusing to {action} {env} non-interactively.\n"
+            f"There is no terminal to confirm on. If you really mean it, be "
+            f"explicit:\n\n    inv {action} --env {env} --yes\n"
+        )
+
+    host = deploy_config.prod_host()
+    print(
+        f"\n{'=' * 70}\n"
+        f"  MANUAL {action.upper()} — this is the fallback path, not the normal one.\n"
+        f"{'=' * 70}\n"
+        f"  Target:  {env} on {host}  ({deploy_config.stack_dir(env)})\n"
+        f"\n"
+        f"  The normal path is: open a PR, merge it to main. CI then runs the\n"
+        f"  tests, deploys demo, health-checks it, and promotes to prod only\n"
+        f"  after an approval — rolling back automatically if anything fails.\n"
+        f"\n"
+        f"  Running this instead means: no tests, no health check, no automatic\n"
+        f"  rollback, and no deployment record. CI will also not know this\n"
+        f"  happened, so the next merge will overwrite it.\n"
+        f"\n"
+        f"  Use it when the pipeline is broken or GitHub is unreachable.\n"
+        f"{'=' * 70}"
+    )
+    if input(f'  Type "{env}" to continue, anything else to abort: ').strip() != env:
+        raise Exit("Aborted.")
 
 
 def _get_sha(c):
@@ -148,11 +205,14 @@ def push(c):
 
 
 @task
-def deploy(c, env=DEFAULT_ENV, tag=None):
+def deploy(c, env=DEFAULT_ENV, tag=None, yes=False):
     """Sync config, pull image, start container.
 
     `--tag` overrides the git SHA; the CI pipeline uses it to roll back to the
-    previously deployed image after a failed health check."""
+    previously deployed image after a failed health check.
+
+    `--yes` skips the manual-deploy confirmation (also skipped in CI)."""
+    _confirm_manual("deploy", env, yes)
     sha = tag or _get_sha(c)
     prod_dir = _prod_dir(env)
 
@@ -184,12 +244,16 @@ def deploy(c, env=DEFAULT_ENV, tag=None):
 
 
 @task
-def release(c, env=DEFAULT_ENV):
-    """Build, push, and deploy."""
+def release(c, env=DEFAULT_ENV, yes=False):
+    """Build, push, and deploy.
+
+    `--yes` skips the manual-deploy confirmation (also skipped in CI)."""
+    _confirm_manual("release", env, yes)
     sha = _get_sha(c)
     build(c)
     push(c)
-    deploy(c, env=env)
+    # already confirmed above — don't ask twice
+    deploy(c, env=env, yes=True)
     print(f"\nRelease complete — SHA: {sha}")
 
 
@@ -206,6 +270,7 @@ def status(c, env=DEFAULT_ENV):
 
 
 @task
-def stop(c, env=DEFAULT_ENV):
+def stop(c, env=DEFAULT_ENV, yes=False):
     """Stop the stack."""
+    _confirm_manual("stop", env, yes)
     _ssh(c, f"{COMPOSE} down", env)


### PR DESCRIPTION
Tild — this one's for you to review and approve, and it's mostly about making the
new setup legible rather than changing how anything works.

## The short version

Deploys now happen by **merging a PR to `main`**. CI runs the tests, deploys demo by
itself, checks it's actually healthy, and then waits for you or Keith to approve before
it touches prod. If a release is broken, it puts the previous version back on its own.

`inv release` still exists and still works — it just isn't the normal way to ship any
more, so this PR makes it look and feel like the emergency exit it now is.

## What changes

**README** gains a `Deploying` section that leads with the normal path and describes
`inv` as the fallback.

**`inv deploy` / `release` / `stop` now ask before doing anything:**

```
======================================================================
  MANUAL RELEASE — this is the fallback path, not the normal one.
======================================================================
  Target:  prod on 192.168.0.191  (/opt/stacks/budgeter)

  The normal path is: open a PR, merge it to main. CI then runs the
  tests, deploys demo, health-checks it, and promotes to prod only
  after an approval — rolling back automatically if anything fails.

  Running this instead means: no tests, no health check, no automatic
  rollback, and no deployment record. CI will also not know this
  happened, so the next merge will overwrite it.

  Use it when the pipeline is broken or GitHub is unreachable.
======================================================================
  Type "prod" to continue, anything else to abort:
```

You have to type the environment name — `y` won't do. `--yes` skips it for scripting, and
**CI skips it automatically**, so the pipeline is unaffected. With no terminal and no CI
marker it refuses outright, so a cron job or script can't deploy prod silently.

**CLAUDE.md** gets the real deploy flow, plus two corrections we found while building
this: `settings.py` does *not* load envars (the Dockerfile's `CMD` does, into PID 1 only —
which is why `docker exec <c> env` shows nothing), and `App.jsx` hasn't been "monolithic"
since the components were split out.

**Dead commands removed:** the README documented `make install`, `make run-backend`,
`make run-frontend` and `make test`. There is no Makefile. Replaced with the commands that
actually work.

## One thing worth knowing

`budgeter.ddns.net` still points at the **old** host, so `inv release --env prod` is
currently the only way to update the app we actually use. The README says so plainly. That
changes when the database moves across — after which merging to `main` becomes the real
release path and `inv` is purely the emergency exit.

## Verification

- Confirmation gate tested on all four paths: CI bypass, `--yes` bypass, non-interactive
  refusal, and the interactive prompt accepting the right answer / aborting on a wrong one.
- `inv --list` still lists all seven tasks; 16/16 deploy-config tests pass.
- No change to the CI workflow itself.