### PR TITLE
docs: split README and CLAUDE.md by audience, fix stale claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,194 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
+
+**README.md owns the commands, the deploy flow and the local setup.** Read it
+first. This file deliberately does not repeat them — it covers what the code
+does not say about itself, and the traps where the obvious move is the wrong
+one.
 
 ## Project Overview
 
-Budgeter is a full-stack budgeting app. It is deployed by CI (GitHub Actions) to 192.168.0.137 on every merge to `main`; the live instance still runs on 192.168.0.191 until the data is migrated. See README.md for the deploy flow. It tracks shared and individual budgets for multiple users with temporal versioning of budget values.
+Budgeter is a full-stack budgeting app for two people. It tracks shared and
+individual budgets with temporal versioning of budget values, plus a shared
+"tabs" ledger and childcare cost calculators.
 
-## Commands
+**This repo is public.** No secrets in the tree — everything sensitive is
+vault-backed in `envars.yml`. `.gitignore` blocks `*.sqlite3` and `.env*` for
+this reason; do not weaken it, and do not commit a database dump.
 
-```bash
-# Install dependencies (backend + frontend)
-cd backend && uv sync
-cd frontend && npm install
+**Where it runs.** CI deploys demo to `192.168.0.137` on every merge to `main`.
+Prod is still `192.168.0.191` — `budgeter.ddns.net` points there, so `.191` is
+the instance real data lives on. The cutover to `.137` is in progress. Until it
+lands, a merge to `main` does *not* update the live app.
 
-# Run locally (two terminals)
-cd backend && uv run manage.py runserver 0.0.0.0:8000
-cd frontend && npm run dev
+## Gotchas
 
-# Database
-cd backend && uv run manage.py migrate
-cd backend && uv run manage.py makemigrations
+Places where the obvious action is the wrong one.
 
-# Tests
-cd backend && uv run manage.py test
-cd backend && uv run manage.py test budget.tests.TestClassName.test_method
-
-# Frontend linting
-cd frontend && npm run lint
-
-# Deploy — NORMAL PATH: merge a PR to main. CI builds, deploys demo,
-# health-checks it, then promotes to prod after a human approval.
-#
-# The invoke tasks below are the FALLBACK for when the pipeline is broken.
-# They bypass tests, health checks and rollback. deploy/release/stop ask for
-# a typed confirmation (--yes skips it; CI skips it automatically).
-inv build                # Build Docker image (SHA + latest)
-inv push                 # Push to the registry
-inv deploy --env prod    # Deploy to prod  (confirmation required)
-inv release --env prod   # Build + push + deploy (confirmation required)
-inv logs --env prod      # Tail logs
-inv status --env prod    # Show containers
-```
-
-All `uv run manage.py` commands must be run from the `backend/` directory.
+- **`docker exec <c> env` will not show the app's secrets.** The Dockerfile's
+  `CMD envars -f /app/envars.yml exec -e $APP_ENV` decrypts them at container
+  start and injects them into PID 1 only. Read `/proc/1/environ` instead.
+  `settings.py` reads plain env vars; it does not load `envars` itself.
+- **All `uv run manage.py` commands must run from `backend/`.**
+- **The OAuth email whitelist is in `settings.py` (`ALLOWED_GOOGLE_EMAILS`), not
+  in `adapters.py`.** `adapters.py` only reads the setting — grepping for
+  "adapter" sends you to the wrong file to edit the list.
+- **Add and rotate secrets with `envars add`**, not the raw `bao`/`vault` CLI.
+- **Never add `pull_request_target` to `.github/workflows/ci.yml`**, and never
+  give that workflow secrets. The `deploy-*` jobs run on a self-hosted homelab
+  runner; the `if:` guards are *not* the security control. Read the comment
+  block above `deploy-demo` before touching anything in that file.
+- **`build.json` and `config.demo.yaml` are dead.** They are leftovers from the
+  old Home Assistant addon packaging; no other tracked file references them and
+  neither the Dockerfile nor CI reads them. Ignore them; don't wire them back in.
 
 ## Architecture
 
 **Backend**: Django 5 + django-ninja (type-annotated REST API) + django-allauth (Google OAuth)
-**Frontend**: React 19 + Vite 7 + Tailwind CSS 4 (single-file SPA in `App.jsx`)
+**Frontend**: React 19 + Vite 7 + Tailwind CSS 4
 **Database**: SQLite (volume-mounted at `/data/db.sqlite3`)
 **Deployment**: Docker multi-stage build → Nginx serves static + proxies to Gunicorn
-**Secrets**: envars.yml with Openbao vault (`http://192.168.0.191:8200`)
+**Secrets**: `envars.yml` with Openbao vault (`http://192.168.0.191:8200`)
 
-### Request Flow (Production)
+### Request flow (production)
 ```
-Client → Nginx Proxy Manager (HA) → Docker container on 191
+Client → Nginx Proxy Manager (HA) → Docker container
   Nginx (:80) inside container:
     /api/*, /accounts/* → Gunicorn (unix socket) → Django
     /static/*           → /app/staticfiles/
-    /*                   → React SPA (/app/static_root/index.html)
+    /*                  → React SPA (/app/static_root/index.html)
 ```
 
-### Deploy Flow
-```
-merge to main
-  1. PR checks (Django, vitest+lint+build, docker build, Playwright e2e) — all required
-  2. deploy-demo   on a self-hosted runner ON 192.168.0.137:
-       build -> push to localhost:5000 -> write .env + compose.yml -> up -d
-       -> poll /api/health (200 + status:ok + matching sha)
-       -> on failure, redeploy the previous IMAGE_TAG and fail the run
-  3. deploy-prod   same host, PROMOTES demo's exact image (no rebuild),
-       gated on the `prod` environment: waits for a reviewer to approve
-```
-Fallback (`inv release --env prod`) still does build -> push -> SSH -> up -d
-against 192.168.0.191, with no health check or rollback.
+### Deploy
+See README.md for the pipeline. Three things worth knowing before you edit it:
 
-`deploy_config.py` holds the host/registry/stack-dir values so they can be
-unit-tested and overridden by `BUDGETER_*` env vars in CI; `tasks.py` consumes it.
+- **This setup is not bespoke.** The `deploy_config.py` + `tasks.py` +
+  self-hosted-runner-on-`.137` shape follows the homelab CI/CD onboarding
+  standard, which is also where the required repo settings (including the fork
+  pull request approval policy that `ci.yml`'s security block depends on) are
+  specified. Read it before changing the pipeline's shape, and prefer keeping
+  in step with it over local improvements:
+  `kthhrv/homelab` → `docs/onboarding-an-app-to-cicd.md`.
+  *That repo is private — the link is unreachable for anyone outside it.*
+- `deploy_config.py` holds the host/registry/stack-dir values as stdlib-only
+  functions so they can be unit-tested and overridden by `BUDGETER_*` env vars
+  in CI. `tasks.py` consumes it. Put config logic there, not in `tasks.py` —
+  `tasks.py` imports `invoke`, which is not a project dependency, so anything
+  living there cannot be tested. Its docstrings explain each override.
+- Remote stack directories: demo `/opt/stacks/budgeter-demo/`, prod
+  `/opt/stacks/budgeter/`.
 
-Remote directory structure:
-- Demo: `/opt/stacks/budgeter-demo/`
-- Prod: `/opt/stacks/budgeter/`
+## Domain model
 
-### Key Backend Files
-- `budget/models.py` — Three models: `Month`, `BudgetItem`, `BudgetItemVersion`
-- `budget/api.py` — All REST endpoints under `/api/`
-- `budgeter/adapters.py` — OAuth email whitelist
-- `budgeter/settings.py` — Django config. Reads plain env vars; it does NOT load
-  envars itself. The Dockerfile's `CMD envars -f /app/envars.yml exec -e $APP_ENV`
-  decrypts them at container start and injects them into PID 1. So
-  `docker exec <c> env` will NOT show them — read `/proc/1/environ` instead.
-- `envars.yml` — Vault-backed secrets per environment
+Six models in `budget/models.py`. Field-level meaning is in each field's
+`help_text` — read that rather than guessing. What follows is the part the
+field definitions don't tell you.
 
-### Data Model Concepts
-- **BudgetItem**: A budget category (expense/income) with an owner (shared/keith/tild)
-- **BudgetItemVersion**: Temporal versioning — tracks value changes per month via `effective_from_month`. Supports rollover and one-off items
-- **Calculation types**: `fixed` (monthly amount) or `weekly_count` (value × weekly occurrences in that month)
-- **Soft deletion**: Items expire via `last_payment_month` rather than being deleted
+**`Month`** — an explicit row per budget month, with `start_date`/`end_date`.
+Months are rows, not values derived from a date, and both `BudgetItemVersion`
+foreign keys point at them — so month logic means joins, not date arithmetic.
 
-### Frontend
-`App.jsx` (~390 lines) holds routing and top-level state; components live in `src/components/`, with `src/hooks/`, `src/services/api.js` and `src/utils/` alongside. It's a PWA with a service worker that excludes `/api/`, `/accounts/`, `/admin/`, `/static/` routes.
+**`BudgetItem`** — a budget category. The interesting axes:
+- `item_type`: `expense`, `income`, or `savings`.
+- `owner`: `shared`, `keith`, or `tild`.
+- `expense_pot`: `bills` or `groceries` — which pot the expense is funded from.
+- `calculation_type`: `fixed` (a monthly amount) or `weekly_count` (value ×
+  the number of times `weekly_payment_day` falls in that month).
+- `is_extra` — funded, but treated as a buffer line: excluded from the joint
+  Expenses total and reflected in Remaining instead.
+- `is_auto_extra` — an Extra whose value *rebalances itself* each month to hold
+  joint Remaining at the stored target.
+- `is_tab_repayment` — this item's monthly value is also emitted as an
+  automatic repayment on the tabs ledger.
+- `childcare_link` — binds the item to a frontend calculator
+  (`ellis_nursery`, `gaspard_care`, `gaspard_holiday`) for the
+  "Sync from Nursery" action.
 
-### Auth
-Google OAuth with a hardcoded email whitelist in `adapters.py`. In local dev, authentication is bypassed/simplified. CSRF tokens are required for state-changing API calls.
+**`BudgetItemVersion`** — temporal versioning, and the concept most likely to
+trip you up. A value change is a *new version*, not an update in place.
 
-### Environment Variables (managed by envars.yml + Openbao vault)
-- `APP_ENV` — environment name (demo/prod/local/test), set via docker-compose .env
-- `DJANGO_SECRET_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `ADDON_DOMAIN`
-- `HA_ACCESS_TOKEN`, `HA_API_URL`, `HA_NOTIFY_ENTITY`
+It carries **two** `Month` foreign keys, and conflating them is the classic
+mistake:
+- `month` — the month this row was recorded *for*. Unique per item
+  (`unique_together = ('budget_item', 'month')`).
+- `effective_from_month` — the month the value starts applying from. This is
+  what drives rollover.
+
+Resolution lives in `_effective_version_for_month` (`api.py:156`) and goes in
+this order:
+1. **An exact `month` match wins outright** — including a one-off.
+2. Otherwise, fall back to the most recent version that is *not* a one-off and
+   whose `effective_from_month` is at or before the target month.
+
+So values roll forward until superseded, `is_one_off` opts a version out of
+that roll-forward, and an explicit entry for a month always beats the rolled-
+forward value. Versions must be prefetched ordered by
+`-effective_from_month__start_date` for that function to be correct — it
+breaks on the first match and trusts the ordering.
+
+**Soft deletion**: items are never deleted. They expire by setting
+`last_payment_month`; anything after that month ignores them. Code that walks
+months must honour this — see the filtering in `api.py`'s tabs endpoint.
+
+**`TabItem` / `TabRepayment`** — a shared-purchase ledger: who paid, the total,
+and how much the other person owes (defaults to 50%, overridable). Repayments
+are of two kinds, and `GET /api/tabs/` merges them: manual `TabRepayment` rows,
+and *synthetic* ones computed from every `BudgetItem` with
+`is_tab_repayment=True`. The synthetic ones are only surfaced for months that
+have already started — future months must not show a repayment yet.
+
+**`NurserySettings`** — a per-user `JSONField` blob (one-to-one with `User`)
+holding the nursery calculator's inputs. Schema-less by design; the shape is
+defined by the frontend calculators, not the model.
+
+**Childcare calculators live in the frontend**, not the backend:
+`src/utils/nurseryCalc.js` (Ellis's nursery invoice model, funded hours, TFC
+caps) and `src/utils/childcareCalc.js` (Gaspard's school breakfast/after-school
+and holiday clubs). Both carry hardcoded rates, term dates and bank holidays
+with source comments — update them there, and note that Gaspard transitions
+from the nursery model to the childcare model at `GASPARD_CARE_START_DEFAULT`.
+
+## Frontend
+
+`App.jsx` holds routing and top-level state. Components live in
+`src/components/`, with `src/hooks/`, `src/services/api.js` and `src/utils/`
+alongside. Unit tests (vitest) sit in `src/test/`; Playwright specs live in
+`frontend/e2e/` and are excluded from the vitest run by `vite.config.js`.
+
+It's a PWA. The service worker's `navigateFallbackDenylist` excludes `/api`,
+`/accounts`, `/admin` and `/static` so those reach the backend instead of being
+answered by the SPA shell — if you add a new server-rendered route, add it
+there too.
+
+## Auth
+
+Google OAuth via django-allauth, restricted to the `ALLOWED_GOOGLE_EMAILS`
+whitelist in `settings.py`.
+
+The API is `NinjaAPI(auth=django_auth)`, so **every endpoint requires an
+authenticated session — including in local dev.** The one exception is
+`/api/health`, which is explicitly `auth=None` because the deploy pipeline
+polls it unauthenticated; leave it that way or every deploy fails. `DEBUG` does
+not relax authentication — it only affects the secret-key fallback,
+`ALLOWED_HOSTS`, cookie flags and http vs https.
+
+State-changing calls need a CSRF token; `services/api.js` sends `X-CSRFToken`
+on every mutation. The Playwright suite gets a session via
+`backend/e2e_seed_session.py`, driven from `frontend/e2e/global-setup.js`.
+
+## Environment variables
+
+Managed by `envars.yml` (vault-backed, per environment: demo/local/prod/test).
+
+Consumed by the app:
+- `APP_ENV` — environment name, set via the compose `.env` file
+- `DJANGO_SECRET_KEY` — required unless `DEBUG` or running tests
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` — read by the `setup_oauth`
+  management command at container start
+- `ADDON_DOMAIN` — falls back to the hostname in `run.sh`
 - `DEBUG` — defaults to false; true for local/test
+
+`HA_ACCESS_TOKEN`, `HA_API_URL` and `HA_NOTIFY_ENTITY` are still defined in
+`envars.yml`, but no tracked file outside `envars.yml` reads them. Treat them
+as unused unless you are deliberately reviving a Home Assistant integration.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,18 @@ no health check, no rollback, no record of what was deployed. Use it when the
 pipeline is broken or GitHub is unreachable.
 
 ```bash
-inv release --env prod    # asks you to type "prod" before it does anything
+inv release --env prod    # build + push + deploy (asks you to type "prod" first)
+inv build                 # build the Docker image (SHA + latest)
+inv push                  # push it to the registry
+inv deploy --env prod     # deploy an already-pushed image (confirmation required)
+inv logs --env prod       # tail the logs
+inv status --env prod     # show the containers
+inv stop --env prod       # stop the stack (confirmation required)
 ```
+
+`deploy`, `release` and `stop` ask for a typed confirmation. `--yes` skips it,
+and it never prompts in CI. With no terminal and no `--yes` it **refuses**
+rather than proceeding, so a cron job or script can't deploy prod silently.
 
 Today it is also the **only** way to update the live app, because
 `budgeter.ddns.net` still points at the old host (`192.168.0.191`). Once that
@@ -67,10 +77,29 @@ docker run -p8000:80 -v /tmp/data:/data -it budgeter
   cd frontend && npm run dev
   ```
 
+- **Database** (all `manage.py` commands run from `backend/`):
+  ```bash
+  cd backend && uv run manage.py migrate
+  cd backend && uv run manage.py makemigrations
+  ```
+
+- **Lint the frontend**:
+  ```bash
+  cd frontend && npm run lint
+  ```
+
 - **Run tests**:
   ```bash
   cd backend && uv run manage.py test      # Django
   cd frontend && npm run test              # vitest
   cd frontend && npm run test:e2e          # Playwright (boots both servers itself)
   python3 -m unittest discover -s tests    # deploy config, from the repo root
+  ```
+
+  All four run in CI and all four must pass before a PR can merge.
+
+  To run a single Django test — the backend suite is split across
+  `tests.py`, `tests_health.py`, `tests_tabs.py` and `tests_weekly.py`:
+  ```bash
+  cd backend && uv run manage.py test budget.tests_tabs.TestClassName.test_method
   ```


### PR DESCRIPTION
## Why

CLAUDE.md's deploy half was current (last touched in #25), but the app/domain half predated the tabs, nursery and childcare work. Six of its claims were wrong, and each would have misdirected an edit — "three models" would have had me add a field believing the Tab models don't exist.

Underneath that, the two docs were competing: README and CLAUDE.md both carried the commands and the deploy flow, and it was CLAUDE.md's copy that had rotted. This PR gives each fact one owner.

## Corrections

All verified against the code, with the surface checked:

| Claim | Reality |
|---|---|
| "Three models: `Month`, `BudgetItem`, `BudgetItemVersion`" | Six — `TabItem`, `TabRepayment`, `NurserySettings` (`models.py:214,240,265`), plus the `/api/tabs/*` and `/api/nursery/settings` endpoints and three page components, none of them documented |
| `item_type` is "expense/income" | `savings` is a third (`models.py:47`). `expense_pot`, `is_extra`, `is_auto_extra`, `is_tab_repayment` and `childcare_link` were also undocumented |
| "single-file SPA in `App.jsx`" | Contradicted CLAUDE.md's own Frontend section three paragraphs later; there are 14 components |
| "whitelist in `adapters.py`" | It's `ALLOWED_GOOGLE_EMAILS` in `settings.py:195`; `adapters.py:11` only reads it |
| "In local dev, authentication is bypassed/simplified" | No such mechanism. `api.py:17` is `NinjaAPI(auth=django_auth)` unconditionally; `DEBUG` only affects the secret-key fallback, `ALLOWED_HOSTS`, cookie flags and http-vs-https. Checked `settings.py`, `api.py`, and a repo-wide grep for `force_login`/bypass markers |
| `HA_ACCESS_TOKEN` / `HA_API_URL` / `HA_NOTIFY_ENTITY` listed as env vars | No tracked file outside `envars.yml` reads them — checked by `git grep` across all tracked files and a targeted grep of `backend/**/*.py`, `tasks.py`, `run.sh` and `.github/`. **`envars.yml` is not touched by this PR**; only the doc's list changed |

## Restructure

**README owns the commands, deploy flow and local setup.** It gains the migration and lint commands, the full `inv` task list, the fail-closed confirmation behaviour (`_confirm_manual` refuses with no TTY and no `--yes`), and how to run a single Django test across the four backend test modules.

**CLAUDE.md owns what the code doesn't say about itself.** It drops the duplicated command and deploy sections for a pointer, drops the `App.jsx` line count (drift bait, no decision value), and gains:

- a **Gotchas** section — `/proc/1/environ` for secrets, the whitelist's real home, `envars add`, never `pull_request_target`, and that `build.json` / `config.demo.yaml` are dead HA-addon leftovers no tracked file references
- a real **domain model** section — the tabs ledger's synthetic repayments from `is_tab_repayment` items, the childcare calculators' location, and the temporal versioning rules

The versioning notes document something previously written down nowhere: `BudgetItemVersion` carries **two** `Month` foreign keys, and `_effective_version_for_month` (`api.py:156`) resolves an exact `month` match *ahead of* the non-one-off `effective_from_month` roll-forward. I got this wrong in my own first draft and only caught it by reading the function.

CLAUDE.md now also points at the homelab CI/CD onboarding standard as the source of the deploy pattern, so future changes stay in step with it. That repo is private, so the pointer is a bare reference with the link's unreachability flagged and none of its contents reproduced in this public repo.

## Risk

Docs only — `git diff --name-only` is `CLAUDE.md` and `README.md`. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)