### PR TITLE
test(e2e): pin month-selector test to a fixed month, not the calendar

### DIFF
--- a/frontend/e2e/budget.spec.js
+++ b/frontend/e2e/budget.spec.js
@@ -44,6 +44,11 @@ test('opens the edit modal from a row and cancels without saving', async ({ page
 });
 
 test('month selector navigates between months', async ({ page }) => {
+    // Pin the starting month via the URL hash (getInitialDate reads #YYYY-MM) so this
+    // test asserts fixed labels regardless of the real calendar month. Without this it
+    // is a time-bomb: it breaks on every month rollover (e.g. it went red on 2026-08-01
+    // because it hardcoded "July 2026" as "the current month").
+    await page.goto('/#2026-07');
     await expect(page.getByRole('heading', { name: 'July 2026' })).toBeVisible();
     await page.getByRole('button', { name: 'Previous month' }).click();
     await expect(page.getByRole('heading', { name: 'June 2026' })).toBeVisible();


### PR DESCRIPTION
## Problem
The `month selector navigates between months` e2e test hardcoded **"July 2026"** as the current month. The app defaults to the *real* current month, so the test was a time-bomb — it went red the instant the calendar rolled over to August (**2026-08-01**).

It surfaced on an unrelated docs PR (#26), but it isn't PR-specific: `e2e` is a **required** status check on `main`, so this red check blocks *every* PR until fixed. (`main` only looks green because CI hasn't run there since 2026-07-25, before the rollover — a re-run today fails identically.)

## Fix
Pin the starting month via the URL hash. `getInitialDate()` reads `#YYYY-MM` from the hash and only falls back to `new Date()` when it's absent, so navigating to `/#2026-07` makes the July→June→July assertions deterministic regardless of when the suite runs. One-line-plus-comment change; no app code touched. No other e2e test hardcodes a date (checked).

## Verification
Ran the full suite locally in a genuinely-August environment (initial load hit `2026-08`, pinned nav then drove `2026-07 → 2026-06 → 2026-07`):

```
24 passed, 2 skipped
```

## Note
Independent of docs PR #26 — that PR should rebase onto `main` once this lands.