### PR TITLE
ops: repoint budgeter kms_key to .137's OpenBao

### DIFF
--- a/envars.yml
+++ b/envars.yml
@@ -1,6 +1,6 @@
 configuration:
   app: budgeter
-  kms_key: openbao:http://192.168.0.191:8200:budgeter
+  kms_key: openbao:http://192.168.0.137:8200:budgeter
   description_mandatory: false
   environments:
   - demo


### PR DESCRIPTION
## What
Flip `envars.yml` `kms_key` from `.191`'s OpenBao to `.137`'s:
```diff
-  kms_key: openbao:http://192.168.0.191:8200:budgeter
+  kms_key: openbao:http://192.168.0.137:8200:budgeter
```

## Why
budgeter prod's **data and traffic are now on `.137`** (cut over 2026-08-02; Tild signed off). The container's DB (104 items) was copied `.191`→`.137` and `budgeter.ddns.net` (via NPM on `.207`) now points at `.137:8080` — verified serving with `.191`'s prod stack stopped.

The **only remaining runtime tie to `.191`** is this `kms_key`: budgeter calls `.191`'s OpenBao at *container start* to decrypt `envars.yml`. Repointing it removes the last dependency, so `.191` can be retired.

## Safety
- `.137`'s OpenBao is an identical lift-and-shift of `.191`'s (same transit keys), so the existing `vault:v1:` ciphertext **decrypts unchanged** — only the host in `kms_key` changes, no secret re-encryption.
- Per design **decision 9**: `kms_key` is baked into the image at build time and shared by demo and prod. On merge the pipeline rebuilds and redeploys both on `.137` (**prod after the `prod` environment approval**), each decrypting against `.137`'s OpenBao. The named `budgeter-data` volume persists across the redeploy → migrated data untouched.
- **Failure mode is safe:** if the `.137` secret path doesn't work, the health check fails and the pipeline auto-rolls-back to the previous `:sha` (which still points at `.191`).

## Verify after deploy
Per the design spec's secret-path check: confirm the `.137` container's `/proc/1/environ` holds the decrypted `DJANGO_SECRET_KEY` / `GOOGLE_CLIENT_*` / `ADDON_DOMAIN` (`docker exec … env` won't show them). That single check proves the cross-host secret path against `.137`'s OpenBao.

## Merge ordering
`e2e` is a required check and is currently red on `main` due to the hardcoded-month time-bomb — **#27 fixes it and should merge first**, then rebase this. Otherwise this PR's `e2e` will fail for the same unrelated reason.