### PR TITLE
docs: document log access on .137 and fix stale cutover claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,12 @@ individual budgets with temporal versioning of budget values, plus a shared
 vault-backed in `envars.yml`. `.gitignore` blocks `*.sqlite3` and `.env*` for
 this reason; do not weaken it, and do not commit a database dump.
 
-**Where it runs.** CI deploys demo to `192.168.0.137` on every merge to `main`.
-Prod is still `192.168.0.191` — `budgeter.ddns.net` points there, so `.191` is
-the instance real data lives on. The cutover to `.137` is in progress. Until it
-lands, a merge to `main` does *not* update the live app.
+**Where it runs.** Both demo and prod run on `192.168.0.137`, deployed by CI on
+merge to `main` (prod only after a human approves it — see README).
+`budgeter.ddns.net` points there via the Nginx Proxy Manager on `192.168.0.207`.
+To reach a running container, `ssh root@192.168.0.137` then `docker logs` /
+`docker exec` on `budgeter` (prod) or `budgeter-demo` (demo). `.191` is being
+decommissioned.
 
 ## Gotchas
 
@@ -49,7 +51,7 @@ Places where the obvious action is the wrong one.
 **Frontend**: React 19 + Vite 7 + Tailwind CSS 4
 **Database**: SQLite (volume-mounted at `/data/db.sqlite3`)
 **Deployment**: Docker multi-stage build → Nginx serves static + proxies to Gunicorn
-**Secrets**: `envars.yml` with Openbao vault (`http://192.168.0.191:8200`)
+**Secrets**: `envars.yml` with Openbao vault (`http://192.168.0.137:8200`)
 
 ### Request flow (production)
 ```

--- a/README.md
+++ b/README.md
@@ -34,10 +34,33 @@ inv stop --env prod       # stop the stack (confirmation required)
 and it never prompts in CI. With no terminal and no `--yes` it **refuses**
 rather than proceeding, so a cron job or script can't deploy prod silently.
 
-Today it is also the **only** way to update the live app, because
-`budgeter.ddns.net` still points at the old host (`192.168.0.191`). Once that
-moves to `.137`, merging to `main` becomes the way real releases happen and
-`inv` is purely the emergency exit.
+Both demo and prod now run on `192.168.0.137`, and `budgeter.ddns.net` (via the
+Nginx Proxy Manager on `192.168.0.207`) points there — so merging to `main` is
+how real releases ship, and `inv` is purely the emergency exit.
+
+### Logs and status
+
+Both stacks run on `192.168.0.137`; the containers are named `budgeter` (prod)
+and `budgeter-demo` (demo). Straight to the host:
+
+```bash
+ssh root@192.168.0.137 'docker logs -f --tail=50 budgeter'        # prod
+ssh root@192.168.0.137 'docker logs -f --tail=50 budgeter-demo'   # demo
+ssh root@192.168.0.137 'docker ps'                                # what's running
+```
+
+`inv logs` / `inv status` work too, but `inv` talks to a **single** host that
+still defaults to the old `.191`, so point it at `.137` (the `--env` flag
+selects the stack, not the host — both stacks live on the same host):
+
+```bash
+BUDGETER_PROD_HOST=192.168.0.137 inv logs   --env demo
+BUDGETER_PROD_HOST=192.168.0.137 inv status --env prod
+```
+
+The app's *decrypted* secrets don't show up in `docker exec <c> env` — they're
+injected into PID 1 only. Read `/proc/1/environ` in the container instead (see
+CLAUDE.md's Gotchas).
 
 ## Building and running locally
 


### PR DESCRIPTION
## Why
budgeter's data and traffic moved to `.137` on 2026-08-02, but the docs hadn't caught up — and **neither file documented how to reach the logs**. Someone following the README today would run `inv logs --env prod`, silently hit the stopped prod on `.191`, and see nothing.

## Changes (docs only)
**README.md**
- New **"Logs and status"** section: the direct path (`ssh root@192.168.0.137 'docker logs -f --tail=50 budgeter'` / `budgeter-demo`) and the `inv` path with the required host override — `inv` talks to a single host that still defaults to `.191`, so `BUDGETER_PROD_HOST=192.168.0.137 inv logs …` is needed. Notes that `--env` selects the stack, not the host.
- Rewrote the stale "`budgeter.ddns.net` still points at `.191` / the `.137` move is future" paragraph: both stacks now run on `.137`, fronted by NPM on `.207`.

**CLAUDE.md**
- "Where it runs" now says both envs run on `.137` (prod after approval) and how to reach a container (`ssh` + `docker logs`/`docker exec` on `budgeter` / `budgeter-demo`).
- OpenBao vault host `.191` → `.137` (matches `envars.yml` after #28).

## Notes
- Verified: no `192.168.0.191` references remain in either file.
- Branch is off current `main` (includes the #27 e2e fix), so all required checks — including `e2e` — should pass.